### PR TITLE
Fix _clean_workspace running in wrong working directory

### DIFF
--- a/src/experiment_runner/pbs_job_manager.py
+++ b/src/experiment_runner/pbs_job_manager.py
@@ -189,6 +189,6 @@ class PBSJobManager:
         # in case any failed job
         if work_dir.is_symlink() and work_dir.is_dir():
             # Payu sweep && setup to ensure the changes correctly && remove the `work` directory
-            command = "payu sweep && payu setup"
+            command = f"cd {path} && payu sweep && payu setup"
             subprocess.run(command, shell=True, check=False)
             print(f"Clean up a failed job {work_dir} and prepare it for resubmission.")


### PR DESCRIPTION
Closes #23 

in https://github.com/ACCESS-NRI/access-experiment-runner/blob/0f11c94fc9c375f0521cabcdc3a97e0cc3a6ffdf/src/experiment_runner/pbs_job_manager.py#L181-L194

the subprocess was run without changing into the experiment directory, so the commands ran in the runner current working directory doesnt contain the experiment `config.yaml`. Hence the commands to fail to locate the required configuration.

The fix is simple just add `cd {path}` beforehand.