### PR TITLE
Support purge_experiments() to safely clean up generated experiments.

### DIFF
--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -215,12 +215,9 @@ class ExperimentRunner(BaseExperiment):
 
             print(f"-- Dry_run {dry_run}; Purge: {branch}: {' '.join(cmd)} in {expt_path}")
             if not dry_run:
-                try:
-                    subprocess.run(cmd, cwd=expt_path, check=True, text=True)
-                    if hard:
-                        shutil.rmtree(expt_path.parent)
-                except subprocess.CalledProcessError as e:
-                    print(f"Error during purge of {branch}: {e}")
+                subprocess.run(cmd, cwd=expt_path, check=True, text=True)
+                if hard:
+                    shutil.rmtree(expt_path.parent)
 
     def _assert_safe_under_test_path(self, path: Path) -> None:
         """

--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import shutil
+import subprocess
 from payu.branch import clone, list_branches
 from .base_experiment import BaseExperiment
 from .pbs_job_manager import PBSJobManager
@@ -179,3 +181,61 @@ class ExperimentRunner(BaseExperiment):
 
         src_branch, restart_tag = entry.split("/", 1)
         return ("restart", src_branch, restart_tag)
+
+    def purge_experiments(
+        self,
+        branches: list[str] = None,
+        hard: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        """
+        Purges generated experiments similarly to `payu sweep --hard` or `payu sweep`.
+
+        Parameters:
+            branches (list[str] | None): List of branches to purge. If None, purges all running branches.
+            hard (bool | False): If True, performs a hard purge removing all files. Defaults to False.
+            dry_run (bool | False): If True, only simulates the purge without deleting files. Defaults to False.
+        """
+        target_branches = branches or list(self.running_branches or [])
+        if not target_branches:
+            raise ValueError("No branches specified for purge and no running_branches available.")
+
+        experiment_paths = [Path(self.test_path) / branch / self.repository_directory for branch in target_branches]
+
+        for expt_path, branch in zip(experiment_paths, target_branches):
+            if not expt_path.exists():
+                print(f"-- Experiment path does not exist, skipping purge: {expt_path}")
+                continue
+
+            self._assert_safe_under_test_path(expt_path)
+
+            cmd = ["payu", "sweep"]
+            if hard:
+                cmd.append("--hard")
+
+            print(f"-- Dry_run {dry_run}; Purge: {branch}: {' '.join(cmd)} in {expt_path}")
+            if not dry_run:
+                try:
+                    subprocess.run(cmd, cwd=expt_path, check=True, text=True)
+                    if hard:
+                        shutil.rmtree(expt_path.parent)
+                except subprocess.CalledProcessError as e:
+                    print(f"Error during purge of {branch}: {e}")
+
+    def _assert_safe_under_test_path(self, path: Path) -> None:
+        """
+        Ensures the given path is under the test_path to prevent accidental deletions.
+
+        Parameters:
+            path (Path): The path to check.
+        """
+        test_path = Path(self.test_path).resolve()
+        target_path = path.resolve()
+
+        # ensure the target path is under test_path
+        try:
+            target_path.relative_to(test_path)
+        except ValueError as e:
+            raise ValueError(
+                f"Refuse to purge outside test_path. test_path: {test_path}, target_path: {target_path}"
+            ) from e

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -285,3 +285,106 @@ def test_resolve_restart_tag_list_length_mismatch(indata):
     er = exp_runner.ExperimentRunner(indata)
     with pytest.raises(ValueError):
         er._resolve_restart_tag(branch="perturb_1", indx=1)
+
+
+def test_purge_experiments_dry_run(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    for branch in indata["running_branches"]:
+        expt_path = Path(er.test_path) / branch / er.repository_directory
+        expt_path.mkdir(parents=True, exist_ok=True)
+
+    calls = []
+
+    def dummy_run(cmd, cwd, check, text):
+        calls.append((cmd, cwd, check, text))
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", dummy_run, raising=True)
+
+    # should not call subprocess.run when dry_run=True
+    er.purge_experiments(dry_run=True)
+
+    assert calls == []
+
+    # for normal run
+    er.purge_experiments(dry_run=False)
+
+    assert len(calls) == len(indata["running_branches"])
+
+    for (cmd, cwd, check, text), branch in zip(calls, indata["running_branches"]):
+        expected_path = Path(er.test_path) / branch / er.repository_directory
+        assert cmd == ["payu", "sweep"]
+        assert cwd == expected_path
+        assert check is True
+        assert text is True
+
+
+def test_purge_experiments_hard(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    for branch in indata["running_branches"]:
+        expt_path = Path(er.test_path) / branch / er.repository_directory
+        expt_path.mkdir(parents=True, exist_ok=True)
+
+    removed = []
+
+    def dummy_run(*args, **kwargs):
+        return 0
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", dummy_run, raising=True)
+
+    def dummy_rmtree(path):
+        removed.append(Path(path))
+
+    monkeypatch.setattr(exp_runner.shutil, "rmtree", dummy_rmtree, raising=True)
+    er.purge_experiments(hard=True, dry_run=False)
+
+    # hard purge should remove parent dirs of experiment dirs
+    expected = [Path(er.test_path) / branch for branch in indata["running_branches"]]
+    assert removed == expected
+
+
+def test_purge_experiments_no_running_branches_raises(indata):
+    indata["running_branches"] = []
+    er = exp_runner.ExperimentRunner(indata)
+    with pytest.raises(ValueError):
+        er.purge_experiments()
+
+
+def test_purge_experiments_branch_does_not_exist(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    # only create one of the experiment dirs
+    branch = indata["running_branches"][0]
+    expt_path = Path(er.test_path) / branch / er.repository_directory
+    expt_path.mkdir(parents=True, exist_ok=True)
+
+    calls = []
+
+    def dummy_run(cmd, cwd, check, text):
+        calls.append((cmd, cwd, check, text))
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", dummy_run, raising=True)
+
+    er.purge_experiments(dry_run=False)
+
+    out = capsys.readouterr().out
+    assert "Experiment path does not exist, skipping purge" in out
+
+    # only one existing branch should have been processed
+    assert len(calls) == 1
+
+
+def test_assert_safe_under_test_path_raises_on_unsafe_path(indata):
+    er = exp_runner.ExperimentRunner(indata)
+    unsafe_path = Path("/etc/passwd")
+    with pytest.raises(ValueError):
+        er._assert_safe_under_test_path(unsafe_path)
+
+
+def test_assert_safe_under_test_path_passes_on_safe_path(indata, tmp_path):
+    er = exp_runner.ExperimentRunner(indata)
+    safe_path = tmp_path / "tests" / indata["running_branches"][0] / indata["repository_directory"]
+    safe_path.mkdir(parents=True, exist_ok=True)
+    # should not raise
+    er._assert_safe_under_test_path(safe_path)


### PR DESCRIPTION
closes #25 

3 options are provided:
- branches: If list is not specified, all experiments under `test_path` will be purged.
- hard: Enables `payu sweep --hard`, otherwise, `payu sweep` is used.
- dry_run: Performs a dry run to simulate the purge without deleting any files.