### PR TITLE
Patch to purge_experiments() to support removing repository_directory

### DIFF
--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -232,19 +232,18 @@ class ExperimentRunner(BaseExperiment):
 
         self._assert_safe_under_test_path(self.base_directory)
 
-        still_used = False
-        for branch in target_branches:
-            branch_repo = Path(self.test_path) / branch / self.repository_directory
-            if branch_repo.exists():
-                still_used = True
-                break
+        still_used = any(
+            (Path(self.test_path) / branch / self.repository_directory).exists() for branch in target_branches
+        )
 
         if still_used:
             print(f"-- Repository directory still in use by other branches, not removing: {self.base_directory}")
             return
 
-        shutil.rmtree(self.base_directory)
-        print(f"-- Removed repository directory: {self.base_directory}")
+        print(f"-- Dry run {dry_run}; Removing repository directory: {self.base_directory}")
+        if not dry_run:
+            shutil.rmtree(self.base_directory)
+            print(f"-- Removed repository directory: {self.base_directory}")
 
     def _assert_safe_under_test_path(self, path: Path) -> None:
         """

--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -187,6 +187,7 @@ class ExperimentRunner(BaseExperiment):
         branches: list[str] = None,
         hard: bool = False,
         dry_run: bool = False,
+        remove_repo_dir: bool = False,
     ) -> None:
         """
         Purges generated experiments similarly to `payu sweep --hard` or `payu sweep`.
@@ -195,6 +196,7 @@ class ExperimentRunner(BaseExperiment):
             branches (list[str] | None): List of branches to purge. If None, purges all running branches.
             hard (bool | False): If True, performs a hard purge removing all files. Defaults to False.
             dry_run (bool | False): If True, only simulates the purge without deleting files. Defaults to False.
+            remove_repo_dir (bool | False): If True, removes the base repository directory if no branches are using it.
         """
         target_branches = branches or list(self.running_branches or [])
         if not target_branches:
@@ -218,6 +220,31 @@ class ExperimentRunner(BaseExperiment):
                 subprocess.run(cmd, cwd=expt_path, check=True, text=True)
                 if hard:
                     shutil.rmtree(expt_path.parent)
+
+        # remove base repository directory if no branches are using it
+        if not (hard and remove_repo_dir):
+            return
+
+        # check if the repository directory still exists
+        if not self.base_directory.exists():
+            print(f"-- Repository directory does not exist, skipping removal: {self.base_directory}")
+            return
+
+        self._assert_safe_under_test_path(self.base_directory)
+
+        still_used = False
+        for branch in target_branches:
+            branch_repo = Path(self.test_path) / branch / self.repository_directory
+            if branch_repo.exists():
+                still_used = True
+                break
+
+        if still_used:
+            print(f"-- Repository directory still in use by other branches, not removing: {self.base_directory}")
+            return
+
+        shutil.rmtree(self.base_directory)
+        print(f"-- Removed repository directory: {self.base_directory}")
 
     def _assert_safe_under_test_path(self, path: Path) -> None:
         """

--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -233,7 +233,7 @@ class ExperimentRunner(BaseExperiment):
         self._assert_safe_under_test_path(self.base_directory)
 
         still_used = any(
-            (Path(self.test_path) / branch / self.repository_directory).exists() for branch in target_branches
+            (Path(self.test_path) / branch / self.repository_directory).exists() for branch in self.running_branches
         )
 
         if still_used:

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import pytest
+import shutil
 import experiment_runner.experiment_runner as exp_runner
 
 
@@ -388,3 +389,120 @@ def test_assert_safe_under_test_path_passes_on_safe_path(indata, tmp_path):
     safe_path.mkdir(parents=True, exist_ok=True)
     # should not raise
     er._assert_safe_under_test_path(safe_path)
+
+
+def test_purge_remove_repo_dir_not_touch_base(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    for branch in indata["running_branches"]:
+        expt_path = Path(er.test_path) / branch / er.repository_directory
+        expt_path.mkdir(parents=True, exist_ok=True)
+
+    base_repo_dir = er.base_directory
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", lambda *args, **kwargs: 0, raising=True)
+
+    real_rmtree = exp_runner.shutil.rmtree
+
+    def fail_rmtree(path):
+        p = Path(path).resolve()
+        if p == base_repo_dir.resolve():
+            raise AssertionError(f"base_directory should not be removed, but rmtree({path}) was called")
+        return real_rmtree(path)
+
+    monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
+
+    # hard=False
+    er.purge_experiments(hard=False, dry_run=False, remove_repo_dir=True)
+
+    # remove_repo_dir=False
+    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=False)
+
+    assert base_repo_dir.exists()
+
+
+def test_purge_remove_repo_dir_removes_base_missing_skips(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    base_repo_dir = er.base_directory
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+
+    # ensure base_directory is removed
+    if er.base_directory.exists():
+        shutil.rmtree(er.base_directory)
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", lambda *args, **kwargs: 0, raising=True)
+
+    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=True)
+
+    out = capsys.readouterr().out
+    assert "Repository directory does not exist, skipping removal" in out
+
+
+def test_purge_remove_repo_dir_still_used_not_remove_base(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    base_repo_dir = er.base_directory
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+
+    for branch in indata["running_branches"]:
+        expt_path = Path(er.test_path) / branch / er.repository_directory
+        expt_path.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", lambda *args, **kwargs: 0, raising=True)
+
+    def fail_rmtree(path):
+        raise AssertionError(f"base_directory should not be removed when still_used, got rmtree({path})")
+
+    monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
+
+    # dry_run=True means branch dirs are not removed, so base dir is still used
+    er.purge_experiments(hard=True, dry_run=True, remove_repo_dir=True)
+
+    out = capsys.readouterr().out
+    assert "Repository directory still in use by other branches, not removing" in out
+    assert base_repo_dir.exists()
+
+
+def test_purge_remove_repo_dir_dry_run_skips_removal(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    base_repo_dir = er.base_directory
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(exp_runner.subprocess, "run", lambda *args, **kwargs: 0, raising=True)
+
+    def fail_rmtree(path):
+        raise AssertionError("Should not delete base_directory on dry_run=True")
+
+    monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
+
+    er.purge_experiments(hard=True, dry_run=True, remove_repo_dir=True)
+
+    out = capsys.readouterr().out
+    assert "Dry run True; Removing repository directory" in out
+    assert er.base_directory.exists()
+
+
+def test_purge_remove_repo_dir_dry_run_false_removes_base(tmp_path, indata, monkeypatch, capsys):
+    er = exp_runner.ExperimentRunner(indata)
+
+    base_repo_dir = er.base_directory
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+
+    removed = []
+    real_rmtree = exp_runner.shutil.rmtree
+
+    def dummy_rmtree(path):
+        removed.append(Path(path))
+        real_rmtree(path)
+
+    monkeypatch.setattr(exp_runner.shutil, "rmtree", dummy_rmtree, raising=True)
+
+    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=True)
+
+    out = capsys.readouterr().out
+    assert f"-- Removed repository directory: {er.base_directory}" in out
+    assert str(er.base_directory) in [str(p) for p in removed]
+    assert not er.base_directory.exists()


### PR DESCRIPTION
This PR adds optional support for removing `<test_path>/<repository_directory>` when no `<test_path>/<branch>/<repository_directory>` directories exist under `<test_path>`.