### PR TITLE
Fix edge case discovered during usage from PayuManager from access-profiling

### DIFF
--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -232,8 +232,9 @@ class ExperimentRunner(BaseExperiment):
 
         self._assert_safe_under_test_path(self.base_directory)
 
+        branches_to_check = list(self.running_branches or [])
         still_used = any(
-            (Path(self.test_path) / branch / self.repository_directory).exists() for branch in self.running_branches
+            (Path(self.test_path) / branch / self.repository_directory).exists() for branch in branches_to_check
         )
 
         if still_used:


### PR DESCRIPTION
A companion fixup PR to #26 and #27 


This fixes a runtime TypeError and ensures consistent behaviour when called from PayuManager in [access-profiling](https://github.com/ACCESS-NRI/access-profiling). 

Before this change, `self.running_branches` is None in the `runner_config` passed from PayuManager.