### PR TITLE
Make purge explicit (all_branches=True), not implicit purge all

### DIFF
--- a/src/experiment_runner/experiment_runner.py
+++ b/src/experiment_runner/experiment_runner.py
@@ -185,6 +185,7 @@ class ExperimentRunner(BaseExperiment):
     def purge_experiments(
         self,
         branches: list[str] = None,
+        all_branches: bool = False,
         hard: bool = False,
         dry_run: bool = False,
         remove_repo_dir: bool = False,
@@ -193,12 +194,19 @@ class ExperimentRunner(BaseExperiment):
         Purges generated experiments similarly to `payu sweep --hard` or `payu sweep`.
 
         Parameters:
-            branches (list[str] | None): List of branches to purge. If None, purges all running branches.
+            branches (list[str] | None): List of branches to purge.
+            all_branches (bool | False): If True, purges all known branches.
             hard (bool | False): If True, performs a hard purge removing all files. Defaults to False.
             dry_run (bool | False): If True, only simulates the purge without deleting files. Defaults to False.
             remove_repo_dir (bool | False): If True, removes the base repository directory if no branches are using it.
         """
-        target_branches = branches or list(self.running_branches or [])
+        if all_branches and branches is not None:
+            raise ValueError("Pass either branches=[...] or all_branches=True")
+
+        if not all_branches and not branches:
+            raise ValueError("No branches specified for purge! Pass either branches=[...] or all_branches=True")
+
+        target_branches = list(self.running_branches or []) if all_branches else list(branches or [])
         if not target_branches:
             raise ValueError("No branches specified for purge and no running_branches available.")
 

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -303,12 +303,12 @@ def test_purge_experiments_dry_run(tmp_path, indata, monkeypatch, capsys):
     monkeypatch.setattr(exp_runner.subprocess, "run", dummy_run, raising=True)
 
     # should not call subprocess.run when dry_run=True
-    er.purge_experiments(dry_run=True)
+    er.purge_experiments(all_branches=True, dry_run=True)
 
     assert calls == []
 
     # for normal run
-    er.purge_experiments(dry_run=False)
+    er.purge_experiments(all_branches=True, dry_run=False)
 
     assert len(calls) == len(indata["running_branches"])
 
@@ -338,7 +338,7 @@ def test_purge_experiments_hard(tmp_path, indata, monkeypatch, capsys):
         removed.append(Path(path))
 
     monkeypatch.setattr(exp_runner.shutil, "rmtree", dummy_rmtree, raising=True)
-    er.purge_experiments(hard=True, dry_run=False)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=False)
 
     # hard purge should remove parent dirs of experiment dirs
     expected = [Path(er.test_path) / branch for branch in indata["running_branches"]]
@@ -349,7 +349,7 @@ def test_purge_experiments_no_running_branches_raises(indata):
     indata["running_branches"] = []
     er = exp_runner.ExperimentRunner(indata)
     with pytest.raises(ValueError):
-        er.purge_experiments()
+        er.purge_experiments(all_branches=True)
 
 
 def test_purge_experiments_branch_does_not_exist(tmp_path, indata, monkeypatch, capsys):
@@ -367,7 +367,7 @@ def test_purge_experiments_branch_does_not_exist(tmp_path, indata, monkeypatch, 
 
     monkeypatch.setattr(exp_runner.subprocess, "run", dummy_run, raising=True)
 
-    er.purge_experiments(dry_run=False)
+    er.purge_experiments(all_branches=True, dry_run=False)
 
     out = capsys.readouterr().out
     assert "Experiment path does not exist, skipping purge" in out
@@ -414,10 +414,10 @@ def test_purge_remove_repo_dir_not_touch_base(tmp_path, indata, monkeypatch, cap
     monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
 
     # hard=False
-    er.purge_experiments(hard=False, dry_run=False, remove_repo_dir=True)
+    er.purge_experiments(all_branches=True, hard=False, dry_run=False, remove_repo_dir=True)
 
     # remove_repo_dir=False
-    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=False)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=False, remove_repo_dir=False)
 
     assert base_repo_dir.exists()
 
@@ -434,7 +434,7 @@ def test_purge_remove_repo_dir_removes_base_missing_skips(tmp_path, indata, monk
 
     monkeypatch.setattr(exp_runner.subprocess, "run", lambda *args, **kwargs: 0, raising=True)
 
-    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=True)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=False, remove_repo_dir=True)
 
     out = capsys.readouterr().out
     assert "Repository directory does not exist, skipping removal" in out
@@ -458,7 +458,7 @@ def test_purge_remove_repo_dir_still_used_not_remove_base(tmp_path, indata, monk
     monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
 
     # dry_run=True means branch dirs are not removed, so base dir is still used
-    er.purge_experiments(hard=True, dry_run=True, remove_repo_dir=True)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=True, remove_repo_dir=True)
 
     out = capsys.readouterr().out
     assert "Repository directory still in use by other branches, not removing" in out
@@ -478,7 +478,7 @@ def test_purge_remove_repo_dir_dry_run_skips_removal(tmp_path, indata, monkeypat
 
     monkeypatch.setattr(exp_runner.shutil, "rmtree", fail_rmtree, raising=True)
 
-    er.purge_experiments(hard=True, dry_run=True, remove_repo_dir=True)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=True, remove_repo_dir=True)
 
     out = capsys.readouterr().out
     assert "Dry run True; Removing repository directory" in out
@@ -500,9 +500,48 @@ def test_purge_remove_repo_dir_dry_run_false_removes_base(tmp_path, indata, monk
 
     monkeypatch.setattr(exp_runner.shutil, "rmtree", dummy_rmtree, raising=True)
 
-    er.purge_experiments(hard=True, dry_run=False, remove_repo_dir=True)
+    er.purge_experiments(all_branches=True, hard=True, dry_run=False, remove_repo_dir=True)
 
     out = capsys.readouterr().out
     assert f"-- Removed repository directory: {er.base_directory}" in out
     assert str(er.base_directory) in [str(p) for p in removed]
     assert not er.base_directory.exists()
+
+
+def test_purge_experiments_requires_explicit_purge(indata):
+    """Refuse implicit purge"""
+    er = exp_runner.ExperimentRunner(indata)
+    with pytest.raises(ValueError):
+        er.purge_experiments()
+
+
+def test_purge_experiments_rejects_branches_and_all_branches(indata):
+    """Refuse both branches and all_branches=True"""
+    er = exp_runner.ExperimentRunner(indata)
+    with pytest.raises(ValueError):
+        er.purge_experiments(branches=["ctrl"], all_branches=True)
+
+
+def test_purge_experiments_explicit_branches_works_without_running_branches(tmp_path, indata, monkeypatch):
+    """Purge explicit branches doesn’t require running_branches"""
+    indata["running_branches"] = []
+    er = exp_runner.ExperimentRunner(indata)
+
+    # Create the branch dir we explicitly request
+    branch = "ctrl"
+    expt_path = Path(er.test_path) / branch / er.repository_directory
+    expt_path.mkdir(parents=True, exist_ok=True)
+
+    calls = []
+    monkeypatch.setattr(
+        exp_runner.subprocess, "run", lambda cmd, cwd, check, text: calls.append((cmd, cwd, check, text)), raising=True
+    )
+
+    er.purge_experiments(branches=[branch], dry_run=False)
+
+    assert len(calls) == 1
+    cmd, cwd, check, text = calls[0]
+    assert cmd == ["payu", "sweep"]
+    assert cwd == expt_path
+    assert check is True
+    assert text is True


### PR DESCRIPTION
What changes in this PR,
- Add `all_branches`: bool = False
- Refuse `branches=None` unless `all_branches=True`
- Keep current behaviour of defaulting to `running_branches`, but only when user explicitly does.

Related: https://github.com/ACCESS-NRI/access-profiling/pull/50/changes#r2766547727