### PR TITLE
Update CD to use containerised-environments-infra payu/dev workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,13 +76,12 @@ jobs:
     if: github.repository == 'ACCESS-NRI/access-experiment-runner' && startsWith(github.ref, 'refs/tags/v')  # exclude forks
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.MODEL_RELEASE_CONDAENV_WORKFLOW_DISPATCH_TOKEN }}
+      GH_TOKEN: ${{ secrets.CONTAINERISED_ENVS_INFRA_WORKFLOW_PAT }}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Dispatch deploy workflow in model-release-condaenv
+      - name: Deploy
         run: |
-          # Dispatch the deploy_payu_dev.yml workflow from the ACCESS-NRI/model-release-condaenv repo
-          gh workflow run deploy_payu_dev.yml \
-            --repo ACCESS-NRI/model-release-condaenv \
-            --ref main
+          gh workflow run \
+            --repo access-nri/containerised-environments-infra \
+            --ref main \
+            release_dev_env.yml \
+            -f environment=payu


### PR DESCRIPTION
NOTE: Same PR as in experiment generator: https://github.com/ACCESS-NRI/access-experiment-generator/pull/92

This PR calls the new workflow `release_dev_env.yml` in [ACCESS-NRI/containerised-environments-infra](https://github.com/ACCESS-NRI/containerised-environments-infra) repository that deploys a new payu/dev module.

I've added a new `secrets.CONTAINERISED_ENVS_INFRA_WORKFLOW_PAT`. Once this PR is merged, `secrets.MODEL_RELEASE_CONDAENV_WORKFLOW_DISPATCH_TOKEN` can be removed.

Closes #33